### PR TITLE
Cannot import NonType for python version 3.9 or older

### DIFF
--- a/gdm-auto-blur.py
+++ b/gdm-auto-blur.py
@@ -6,7 +6,9 @@ import textwrap
 import tempfile
 import subprocess
 from pathlib import Path
-from types import NoneType
+#from types import NoneType
+
+NoneType = type(None)
 
 try:
     from PIL import Image, ImageFilter, ImageEnhance

--- a/gdm-auto-blur.py
+++ b/gdm-auto-blur.py
@@ -6,9 +6,12 @@ import textwrap
 import tempfile
 import subprocess
 from pathlib import Path
-#from types import NoneType
 
-NoneType = type(None)
+try:
+    # Python 3.10+
+    from types import NoneType
+except:
+    NoneType = type(None)
 
 try:
     from PIL import Image, ImageFilter, ImageEnhance


### PR DESCRIPTION
- I got an error show that ImportError: cannot import name 'NoneType' from 'types' for my python version (3.9)

![image](https://user-images.githubusercontent.com/71642028/213882313-97fa2497-a4b3-44a0-a489-75a314de21a0.png)

- And for the dependencies (on Arch Linux i had to install tk ```sudo pacman -S tk``` before i could use the script - python 3.10.9)

![image](https://user-images.githubusercontent.com/71642028/213882980-d3a4e03d-0105-4522-99b8-99a4063ed85b.png)